### PR TITLE
NEWS: Improve changelog for Turris OS 6.3.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,12 +2,11 @@
 -----
 
 🚀 New Features
-  • diagnostics: report files which have been changed compared to the package, but are not meant to be mutable
-
-🐛 Bug Fixes
-  • foris-controller-librespeed-module: fix reading data_dir from UCI
+  • Added lighttpd error log into diagnostics
+  • Added file consistency check into diagnostics
 
 📌 Updates
+  • Based on the latest OpenWrt 21.02.7 version
   • updater-ng: update to 70.2.0
   • OpenSSL: fix CVE-2023-464 and CVE-2023-465
 


### PR DESCRIPTION
Hi guys!

I have checked what you have been doing in Turris, but I think that the changelog is not how it should be. Your changelog is too advanced, or let's say for geeks, who knows something about it. Remember that the release notes are sent to each Turris user and most of them are not tech savvy. :-( What I have on my mind is that they don't know what is UCI and the sentence about diagnostics is too complex and even for me, it was really tough to understand what you want to say.

However, what you have missed and what you should let users know that Turris OS 6.3.2 is formally based on the latest stable OpenWrt version that should be mentioned in the first place, as I said here https://github.com/turris-cz/os-build/pull/1#issuecomment-1520031597 . 

Please check it, if you like it, then fine. If you don't, just thinking about it in the future and what could be done better.

Also, I think that the updater can be dropped from the changelog as it does not say anything useful. You can paste it on forum or reddit, where are curious users about that.

cc: @paper42, @miska 

BTW: What about kernel versions? Would it be updated? What is blocking it?