### PR TITLE
patches/packages: python3: include release number: rebase

### DIFF
--- a/patches/packages/to-upstream/0011-python3-Make-python-version-part-of-release-number.patch
+++ b/patches/packages/to-upstream/0011-python3-Make-python-version-part-of-release-number.patch
@@ -20,7 +20,7 @@ index 36f4ab07e..e65f9bb32 100644
  
 +PKG_RELEASE:=$(PYTHON3_VERSION)-$(PKG_RELEASE)
 +
- -include $(PYTHON3_LIB_DIR)/config-$(PYTHON3_VERSION)/Makefile-vars
+ -include $(PYTHON3_LIB_DIR)/openwrt/Makefile-vars
  
  # These configure args are needed in detection of path to Python header files
 -- 


### PR DESCRIPTION
Due to changes in upstream, it is necessary to rebase this patch, otherwise it is not applied.

With this one ``prepare_tools`` from the script ``compile_pkgs`` works. Not tested everything else. If you provide publicly some fail logs, I might look into it. 

Not sure, if I should continue sending PRs as I am getting ignored, but who knows. I am doing this for me.