### PR TITLE
Avoiding being vendor locked

### DIFF
--- a/compile_pkgs
+++ b/compile_pkgs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # OpenWRT compilation script
 # (C) 2018-2020 CZ.NIC, z.s.p.o.
 #

--- a/compile_pkgs
+++ b/compile_pkgs
@@ -111,7 +111,7 @@ configure() {
 	[ -n "${TARGET_BOARD:-}" ] || die "No board selected!"
 	rm -f .config
 	cat "${src_dir}/configs/common"/* "${src_dir}/configs/${TARGET_BOARD}"/* | grep "^CONFIG.*=" | while IFS="=" read -r name value; do
-		[ \! -f .config ] || sed -i "/^$name=/ d" .config
+		[ \! -f .config ] || { sed "/^$name=/d" .config > .config.tmp && mv .config.tmp .config; }
 		echo "$name=$value" >> .config
 	done
 	cp .config .config_generated

--- a/compile_pkgs
+++ b/compile_pkgs
@@ -188,8 +188,8 @@ set_ccache() {
 	[ "${CCACHE_SET:-n}" == "y" ] && return 0
 	report "Setting ccache paths"
 	CCACHE_SET=y
-	[ -z "$CCACHE_HOST_DIR" ] || sed -i 's|$(STAGING_DIR_HOST)/ccache|'"$CCACHE_HOST_DIR|" include/host-build.mk
-	[ -z "$CCACHE_TARGET_DIR" ] || [ -z "$TARGET_ARCH" ] || sed -i 's|$(STAGING_DIR)/ccache|'"$CCACHE_TARGET_DIR/$TARGET_ARCH|" include/package.mk
+	[ -z "$CCACHE_HOST_DIR" ] || { sed 's|$(STAGING_DIR_HOST)/ccache|'"$CCACHE_HOST_DIR|" include/host-build.mk > include/host-build.mk.tmp && mv include/host-build.mk.tmp include/host-build.mk; }
+	[ -z "$CCACHE_TARGET_DIR" ] || [ -z "$TARGET_ARCH" ] || { sed 's|$(STAGING_DIR)/ccache|'"$CCACHE_TARGET_DIR/$TARGET_ARCH|" include/package.mk > include/package.mk.tmp && mv include/package.mk.tmp include/package.mk; }
 	[ -z "$(git diff include/host-build.mk include/package.mk)" ] || _git commit -m "include: ccache settings" include/host-build.mk include/package.mk
 }
 

--- a/helpers/turris-version.sh
+++ b/helpers/turris-version.sh
@@ -18,7 +18,7 @@
 news_file="$(dirname "$(dirname "$(readlink -f "$0")")")/NEWS"
 
 get_version() {
-	sed -n '/^-\+$/{x;p;q}; x' "$news_file"
+	awk 'prev && /^-+$/ { print prev; exit } { prev = $0 }' "$news_file"
 }
 
 news_text() {

--- a/helpers/turris-version.sh
+++ b/helpers/turris-version.sh
@@ -13,7 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see http://www.gnu.org/licenses/.
 
 news_file="$(dirname "$(dirname "$(readlink -f "$0")")")/NEWS"
 


### PR DESCRIPTION
OpenWrt allows to be compiled on all operating systems including MacOS, FreBSD, etc. 
See: https://openwrt.org/docs/guide-developer/toolchain/install-buildsystem

Currently, Turris OS scripts are currently vendor-locked, so it can be used mostly on Debian/Ubuntu/openSUSE, Gentoo. 

Check individual commits:

### 1. compile_pkgs
```
./compile_pkgs prepare_tools -t turris1x
Please use Bash version 5.0 or newer!
```

By default, there is this version:
```
/bin/bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin24)
Copyright (C) 2007 Free Software Foundation, Inc.
```

but I do have ``bash`` from ``homebrew``:
```
which bash
/opt/homebrew/bin/bash

bash --version
GNU bash, version 5.2.37(1)-release (aarch64-apple-darwin24.2.0)
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

### 2. Package ``turris-version`` has empty version
Fails because of
```
sed: 1: "/^-\+$/{x;p;q}; x": extra characters at the end of q command
```

It Makefile it is empty:
```
PKG_VERSION:=
```

**The culprit: BSD/GNU sed differs.**  What about using ``awk``? 😇 Its BSD and GNU compatible.

### 3. Option configure does not work

Before:
```
./compile_pkgs configure -t turris1x
Setting target as turris1x
Creating default configuration
sed: 1: ".config": invalid command code .
```

After:
It just works. 


This fixes already one more year ago issue on your GitLab, which I reported to @aleksan4eg
https://gitlab.nic.cz/turris/os/build/-/issues/420 and because Alex does not have much free capacity on his Macbook, it requires only 1 GB storage to be tested.

Can I have this merged, please? 🙏 🙏 