### PR TITLE
patches/openwrt: uboot-mpc85xx: fix PKG_MIRROR_HASH

### DIFF
--- a/patches/openwrt/to-upstream/0051-uboot-mpc85xx-add-Turris-1.x-versions-for-SD-and-NOR.patch
+++ b/patches/openwrt/to-upstream/0051-uboot-mpc85xx-add-Turris-1.x-versions-for-SD-and-NOR.patch
@@ -27,7 +27,7 @@ index 0000000000..db057bfba2
 +
 +PKG_SOURCE_PROTO:=git
 +PKG_SOURCE_URL:=https://gitlab.nic.cz/turris/u-boot.git
-+PKG_MIRROR_HASH:=bc6794736adbdb7e5143ed2afb23fe30c253480a5a49267f08d34bf95b042ec2
++PKG_MIRROR_HASH:=0baef19baf7d41a0e43fe96bda61d5c46bc447db5373c7d6f9d1f1f6ab0c03b1
 +PKG_SOURCE_DATE:=2024-05-10
 +PKG_SOURCE_VERSION:=cf50dc0956a2b99dff735ca08a6b72446950ea7f
 +PKG_BUILD_DEPENDS:=swig/host python-poetry-core/host


### PR DESCRIPTION
Fixes:
Hash of the local file u-boot-2024.05.10~cf50dc09.tar.zst does not match (file: 0baef19baf7d41a0e43fe96bda61d5c46bc447db5373c7d6f9d1f1f6ab0c03b1, requested: bc6794736adbdb7e5143ed2afb23fe30c253480a5a49267f08d34bf95b042ec2) - deleting download.

Related to
- OpenWrt main repo commit: aa29c755fab4552b03755261bfc3cc89154ebcac ("treewide: update PKG_MIRROR_HASH after APK version schema")

____

Btw: to speed up your builds, I suggest that you should do the same for all the packages, because I am quite sure that this issue is in most of your packages including Turris OS packages repository. See: https://github.com/openwrt/openwrt/pull/14960