### PR TITLE
patches/openwrt: fix fw_env.config offset for Turris 1.x

### DIFF
--- a/patches/openwrt/wip/0002-Add-Turris-1.X-support-kernel-6.6.patch
+++ b/patches/openwrt/wip/0002-Add-Turris-1.X-support-kernel-6.6.patch
@@ -25,7 +25,7 @@ index a74466ab3a..58f73c6036 100644
  
  case "$board" in
 +cznic,turris1x)
-+	ubootenv_add_uci_config "/dev/mtd5" "0x20000" "0x2000" "0x20000"
++	ubootenv_add_uci_config "/dev/mtd5" "0x0" "0x2000" "0x20000"
 +	;;
  enterasys,ws-ap3715i)
  	ubootenv_add_uci_config "$(find_mtd_part 'cfg1')" "0x0" "0x10000" "0x10000"


### PR DESCRIPTION
mtd5 is now the dedicated 128 KiB u-boot-env partition, but fw_env.config still uses the old 0x20000 offset from the previous partition layout. The offset points past the end of the partition, so every fw_printenv and fw_setenv invocation fails.

Use offset 0x0, where the environment starts in the current layout. Verified on a Turris 1.1 with the factory U-Boot 2015.04 environment. Found while working on https://github.com/openwrt/openwrt/pull/24755, where the OpenWrt uboot-envtools entry uses the same corrected values.
