### PR TITLE
omnia-ng: Fix GPON SFP WAN loss after the upstream-SFP rework

### DIFF
--- a/src/omnia-ng/openwrt/package/kernel/qca-ssdk/patches/0002-sfp-fix-link-propagation-for-late-modules.patch
+++ b/src/omnia-ng/openwrt/package/kernel/qca-ssdk/patches/0002-sfp-fix-link-propagation-for-late-modules.patch
@@ -1,0 +1,77 @@
+Fix link propagation for SFP modules that appear late
+
+A GPON module like the Zyxel PMG3000-D20B boots its EEPROM emulation
+tens of seconds after power-up, so its module PHY is connected long
+after the netdev was opened. Nothing drives that inner PHY's state
+machine in this case (phylink would), so the link never reaches the
+port: the SFP core sits in link_up while the MAC stays NO-CARRIER,
+and only bouncing the netdev recovers it.
+
+Poll the module PHY from the port PHY's read_status instead of relying
+on the inner state machine, never hard-fail config_aneg on an absent
+module (phylib treats that as fatal and halts the port permanently),
+stop a started module PHY before suspending it on disconnect, and
+report the tracked link state instead of a constant in the HSL status
+path.
+
+--- a/src/hsl/phy/sfp_phy.c
++++ b/src/hsl/phy/sfp_phy.c
+@@ -381,6 +381,8 @@
+ 
+ 	pl->phydev = NULL;
+ 
++	if (phy_is_started(phy))
++		phy_stop(phy);
+ 	phy_suspend(phy);
+ 	phy->phylink = NULL;
+ 
+@@ -548,9 +550,13 @@
+ sfp_phy_config_aneg(struct phy_device *upstream)
+ {
+ 	struct sfp_priv *pl = get_sfp_priv(upstream);
+- 
++
++	/* An error here puts phylib into PHY_ERROR and permanently halts
++	 * the port's state machine. Without a module there is nothing to
++	 * configure yet; the configuration happens on module insert.
++	 */
+ 	if (!pl->module_present)
+-		return -ENODEV;
++		return 0;
+ 
+ 	/* TODO: support pause bits */
+ 	if (pl->phydev) {
+@@ -598,6 +604,24 @@
+ sfp_read_status(struct phy_device *phydev)
+ {
+ 	struct sfp_priv *pl = get_sfp_priv(phydev);
++
++	/* A module PHY that appears while the port is already open has
++	 * nobody driving its state machine (phylink would handle this),
++	 * so poll it from here: the port's own 1Hz poll then reflects
++	 * the module PHY's state regardless of the order in which the
++	 * module, the cage and the netdev came up.
++	 */
++	if (pl->phydev) {
++		struct phy_device *inner = pl->phydev;
++		int err;
++
++		mutex_lock(&inner->lock);
++		err = phy_read_status(inner);
++		mutex_unlock(&inner->lock);
++		if (!err)
++			sfp_phy_link_change(inner, inner->link);
++	}
++
+ 	phydev->link = pl->link_config.link;
+ 	phydev->speed = pl->link_config.speed;
+ 	phydev->duplex = pl->link_config.duplex;
+@@ -805,7 +829,7 @@
+ 		return SW_OK;
+ 	}
+ 
+-	phy_status->link_status = pl->phydev ? pl->link_config.link : 1;
++	phy_status->link_status = pl->module_present && pl->link_config.link;
+ 	phy_status->speed = pl->link_config.speed;
+ 	phy_status->duplex = pl->link_config.duplex;
+ 

--- a/src/omnia-ng/openwrt/target/linux/ipq95xx/patches-6.6/ff94-net-sfp-add-quirk-for-Zyxel-PMG3000-D20B.patch
+++ b/src/omnia-ng/openwrt/target/linux/ipq95xx/patches-6.6/ff94-net-sfp-add-quirk-for-Zyxel-PMG3000-D20B.patch
@@ -1,0 +1,19 @@
+net: sfp: add quirk for Zyxel PMG3000-D20B GPON module
+
+Deutsche Telekom's standard GPON SFP boots its EEPROM emulation tens of
+seconds after power up and can drop off the bus once during that boot,
+like the Alcatel Lucent G-010S-A. Give it the same long start-up time.
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -498,6 +498,10 @@
+ 
+ 	SFP_QUIRK_M("UBNT", "UF-INSTANT", sfp_quirk_ubnt_uf_instant),
+ 
++	// Zyxel PMG3000-D20B GPON module boots its EEPROM emulation tens of
++	// seconds after power up, like the Alcatel Lucent G-010S-A.
++	SFP_QUIRK_F("ZYXEL", "PMG3000-D20B", sfp_fixup_long_startup),
++
+ 	// Walsun HXSX-ATR[CI]-1 don't identify as copper, and use the
+ 	// Rollball protocol to talk to the PHY.
+ 	SFP_QUIRK_F("Walsun", "HXSX-ATRC-1", sfp_fixup_fs_10gt),

--- a/src/omnia-ng/openwrt/target/linux/ipq95xx/patches-6.6/ff95-net-sfp-report-probe-failures.patch
+++ b/src/omnia-ng/openwrt/target/linux/ipq95xx/patches-6.6/ff95-net-sfp-report-probe-failures.patch
@@ -1,0 +1,32 @@
+net: sfp: do not fail sfp_probe silently
+
+A GPIO request that fails in sfp_probe returns the error without any
+message, so a cage that loses a probe race against its GPIO expander
+disappears without a trace: not bound, not deferred, nothing logged.
+Use dev_err_probe so the failure is visible (and a deferral shows its
+reason in /sys/kernel/debug/devices_deferred).
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -2993,7 +2997,8 @@
+ 
+ 	i2c = i2c_get_adapter_by_fwnode(h);
+ 	if (!i2c) {
+-		err = -EPROBE_DEFER;
++		err = dev_err_probe(sfp->dev, -EPROBE_DEFER,
++				    "i2c bus not ready\n");
+ 		goto put;
+ 	}
+ 
+@@ -3037,7 +3042,10 @@
+ 			sfp->gpio[i] = devm_gpiod_get_optional(sfp->dev,
+ 					   gpio_names[i], gpio_flags[i]);
+ 			if (IS_ERR(sfp->gpio[i]))
+-				return PTR_ERR(sfp->gpio[i]);
++				return dev_err_probe(sfp->dev,
++						     PTR_ERR(sfp->gpio[i]),
++						     "failed to get '%s' GPIO\n",
++						     gpio_names[i]);
+ 		}
+ 
+ 	sfp->state_hw_mask = SFP_F_PRESENT;


### PR DESCRIPTION
Since the switch to the upstream SFP subsystem (827dfdf9, first shipped in 9.0.3), a
Turris Omnia NG with a Zyxel PMG3000-D20B GPON module (Deutsche Telekom's standard
ONT stick) loses its WAN: after updating from 9.0.0 to 9.1.1 the PPPoE uplink on the
SFP cage never comes back, and only a `schnapps` rollback restores connectivity.

Two independent bugs, isolated by tracing a failing 9.1.1 boot against a working
9.0.0 one on the same device:

1. **The module PHY's link never reaches the MAC.** This module boots its EEPROM
   emulation tens of seconds after power up, so its (emulated, I2C 0x56) module PHY
   is connected long after the netdev was opened. The qca-ssdk glue drives the inner
   PHY's link only through that PHY's own phylib state machine, which nothing starts
   on this path — the SFP core then sits in `link_up` (rx_los clear, tx enabled,
   `eth4: switched to 1000base-x link mode` logged) while the port stays NO-CARRIER
   indefinitely; `ip link set eth4 down && ip link set eth4 up` recovers it, which is
   how the fix was pinned down. The first commit makes the port PHY's `read_status`
   poll the module PHY directly (the phylink-equivalent behaviour), stops a started
   module PHY on disconnect, no longer hard-fails `config_aneg` while no module is
   present (phylib treats the error as fatal and halts the port permanently), and
   reports the tracked link state instead of a constant in the HSL status path.

2. **The sfp platform probe fails silently on roughly half of all boots.** `sfp0`
   /`sfp1` race the pcal6408 GPIO expanders behind the I2C mux; the loser is left
   unbound, not deferred, with nothing logged (`sfp_probe()` returns GPIO errors
   without a message). A later manual `echo sfp0 > /sys/bus/platform/drivers/sfp/bind`
   always succeeds, so the failure is transient. The second commit adds
   `dev_err_probe` so the next occurrence names the failing GPIO and errno instead of
   disappearing; the race itself is left to fix once that errno is known.

The third commit gives the PMG3000-D20B the same long-startup quirk as the Alcatel
Lucent G-010S-A — its EEPROM emulation appears late and can drop off the bus once
while booting.

Both bugs are specific to the Omnia NG: the glue only exists because the NSS
ethernet driver cannot use phylink (which handles a module appearing after the
netdev opened by design), and the probe race comes from the NG's SFP control GPIOs
sitting on pcal6408 expanders behind the I2C mux. The two sfp.c patches are generic,
though: the module's late EEPROM emulation is exactly openwrt/openwrt#17733 (same
stick on a BPI-R4), and silent `sfp_probe` failures hide this class of bug on any
platform — both are candidates for mainline, and are only carried here because this
is where TurrisOS keeps its ipq95xx kernel patches.

**Testing:** on an Omnia NG on a live Telekom GPON line, TurrisOS 9.1.1 with the
patched `qca-ssdk.ko` (built in the 9.1.0 buildroot, vermagic-identical): module
detected ~62s after boot, port linked within 300ms of detection with no manual
intervention, PPPoE up 20s later. Unpatched 9.1.1 on the same device never linked
(observed over four instrumented boots, including a 240s watch of
`/sys/kernel/debug/sfp0/state` showing the SFP core at `link_up` throughout while
the MAC stayed down). The kernel patches apply and compile cleanly; the
diagnosability one is untested against a live occurrence of the race by nature.

Written with AI assistance; I have reviewed and understand all of it and will
answer questions myself.